### PR TITLE
Add Python 3.11 support for pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ MANIFEST
 # cache
 *.pyc
 **/__pycache__
+_skbuild/
 
 # built binary objects
 *.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,101 @@
+# Modified from https://numpy.org/doc/stable/f2py/buildtools/skbuild.html#cmake-modules-only
+
+### setup project ###
+cmake_minimum_required(VERSION 3.9)
+
+project(phaseshifts
+  VERSION 0.1.7
+  DESCRIPTION "LIBPHSH module"
+  LANGUAGES C Fortran
+  )
+
+# Safety net
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(
+    FATAL_ERROR
+      "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there.\n"
+  )
+endif()
+
+# Ensure scikit-build modules
+if (NOT SKBUILD)
+  find_package(PythonInterp 3.12 REQUIRED)
+  # If skbuild is not the driver; include its utilities in CMAKE_MODULE_PATH
+  execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}"
+    -c "import os, skbuild; print(os.path.dirname(skbuild.__file__))"
+    OUTPUT_VARIABLE SKBLD_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  list(APPEND CMAKE_MODULE_PATH "${SKBLD_DIR}/resources/cmake")
+  message(STATUS "Looking in ${SKBLD_DIR}/resources/cmake for CMake modules")
+endif()
+
+# scikit-build style includes
+find_package(PythonExtensions REQUIRED) # for ${PYTHON_EXTENSION_MODULE_SUFFIX}
+
+# Grab the variables from a local Python installation
+# NumPy headers
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}"
+  -c "import numpy; print(numpy.get_include())"
+  OUTPUT_VARIABLE NumPy_INCLUDE_DIRS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+# F2PY headers
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}"
+  -c "import numpy.f2py; print(numpy.f2py.get_include())"
+  OUTPUT_VARIABLE F2PY_INCLUDE_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Prepping the module
+set(f2py_module_name "libphsh")
+set(f2py_module_dirpath "phaseshifts/lib")
+set(fortran_src_file "${CMAKE_SOURCE_DIR}/${f2py_module_dirpath}/${f2py_module_name}.f")
+set(f2py_module_c "${f2py_module_name}module.c")
+set(f2py_wrapper_f "${f2py_module_name}-f2pywrappers.f")
+
+# Target for enforcing dependencies
+add_custom_target(genpyf
+  DEPENDS "${fortran_src_file}"
+)
+add_custom_command(
+  OUTPUT "${f2py_module_c}" "${f2py_wrapper_f}"
+  COMMAND ${PYTHON_EXECUTABLE} -m "numpy.f2py"
+      -m "${f2py_module_name}"
+      --lower # Important
+      "${fortran_src_file}"
+  DEPENDS "${fortran_src_file}" # Fortran source
+)
+
+add_library("${f2py_module_name}" MODULE
+            "${f2py_wrapper_f}"
+            "${f2py_module_c}"
+            "${F2PY_INCLUDE_DIR}/fortranobject.c"
+            "${fortran_src_file}")
+
+target_include_directories("${f2py_module_name}" PUBLIC
+                           ${F2PY_INCLUDE_DIR}
+                           ${NumPy_INCLUDE_DIRS}
+                           ${PYTHON_INCLUDE_DIRS})
+
+set_target_properties("${f2py_module_name}" PROPERTIES SUFFIX "${PYTHON_EXTENSION_MODULE_SUFFIX}")
+set_target_properties("${f2py_module_name}" PROPERTIES PREFIX "")
+
+
+
+if (UNIX)
+  if (APPLE)
+    set_target_properties("${f2py_module_name}" PROPERTIES
+    LINK_FLAGS  '-Wl,-dylib,-undefined,dynamic_lookup')
+  else()
+    set_target_properties("${f2py_module_name}" PROPERTIES
+  LINK_FLAGS  '-Wl,--allow-shlib-undefined')
+  endif()
+endif()
+
+add_dependencies("${f2py_module_name}" genpyf)
+
+install(TARGETS "${f2py_module_name}" DESTINATION phaseshifts/lib/)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,6 @@ recursive-include phaseshifts/lib *.f *.c *.cpp *.h *.for *.py *.pyx
 recursive-exclude phaseshifts/build *
 recursive-exclude phaseshifts/dist *
 recursive-include phaseshifts/res *
+
+# TODO: Remove shared libraries from source distribution includes once numpy.distutils migration is stable 
+recursive-include phaseshifts/lib  *.so *.pyd

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,40 @@
-wheel: deps
-	NPY_DISABLE_CPU_FEATURES="AVX512F AVX512_SKX" python setup.py build bdist_wheel
+# Makefile for assisting with some common development activities
 
-deps:
-	pip install wheel numpy setuptools
+PYTHON ?= $(shell pyenv which python 2>/dev/null || echo python)
+
+.PHONY: wheel install-deps libphsh check test clean
+
+#: Quickly generate binary wheel
+wheel: install-deps
+	$(PYTHON) setup.py build bdist_wheel
+
+#: Install dependencies
+install-deps:
+	$(PYTHON) -m pip install wheel numpy setuptools meson ninja pytest scikit-build
+
+#: Install library into current virtualenv
+install:
+	$(PYTHON) -m pip install .
+
+libphsh.cmake:
+	cmake -S . -B build \
+		-DPYTHON_INCLUDE_DIR="$$($(PYTHON) -c "import sysconfig; print(sysconfig.get_path('include'))")"  \
+		-DPYTHON_LIBRARY="$$($(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")"
+	FFLAGS="-fallow-argument-mismatch -std=f95" \
+		cmake --build build
+
+#: Build the f2py wrapped libphsh shared library within source tree  
+libphsh:
+	$(PYTHON) setup.py build_ext --inplace
+
+#: Perform checks
+check: libphsh
+	$(PYTHON) -m pytest tests/
+
+test: check
+
+#: Remove any artifacts
+clean:
+	rm -rf build dist _skbuild \
+		phaseshifts/lib/libphshmodule.c phaseshifts/lib/libphsh-f2pywrappers.f \
+		phaseshifts/lib/libphsh*.so phaseshifts/lib/libphsh*.pyd

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,20 @@ information please read the documentation at `<http://pythonhosted.org//phaseshi
 Install
 =======
 
+TDLR;
+-----
+
+For python 3.11 or older::
+
+  pip install wheel numpy setuptools
+  pip install -e .
+  phsh --help
+
+Details
+-------
+
 The `phaseshifts <http://https://pypi.python.org/pypi/phaseshifts/>`_ package 
-requires CPython 2.6 or later and also uses the `numpy 
+requires CPython 2.7 or later and also uses the `numpy 
 <http://www.scipy.org/scipylib/download.html>`_, `scipy 
 <http://www.scipy.org/scipylib/download.html>`_ and `periodictable 
 <http://https://pypi.python.org/pypi/periodictable>`_ packages. 

--- a/phaseshifts/__init__.py
+++ b/phaseshifts/__init__.py
@@ -1,11 +1,4 @@
-from pkg_resources import get_distribution, DistributionNotFound
+__project__ = "phaseshifts"
+__version__ = "0.1.7"
 
-__project__ = 'phaseshifts'
-__version__ = None  # required for initial installation
-
-try:
-    __version__ = get_distribution(__project__).version
-except DistributionNotFound:
-    VERSION = __project__ + '-' + '(local)'
-else:
-    VERSION = __project__ + '-' + __version__
+VERSION = __project__ + "-" + __version__

--- a/phaseshifts/lib/__init__.py
+++ b/phaseshifts/lib/__init__.py
@@ -1,0 +1,6 @@
+"""The subpackage is for library code, likely compiled from Fortran or C sources."""
+from ._fortran_lib import is_module_importable, compile_f2py_shared_library, FORTRAN_LIBS, LIBPHSH_MODULE
+
+# NOTE: Attempt to compile libphsh library on import if not already available, useful when installing from source dist
+if not is_module_importable(LIBPHSH_MODULE):
+    compile_f2py_shared_library(**FORTRAN_LIBS[LIBPHSH_MODULE])

--- a/phaseshifts/lib/_fortran_lib.py
+++ b/phaseshifts/lib/_fortran_lib.py
@@ -1,0 +1,59 @@
+"""This module can be used for checking whether Fortran wrapped libraries such as `libphsh` hve compiled successfully.
+
+Notes
+-----
+
+The functionality currently targets `libphsh.f` by default and provides utilities to check for the
+compiled wrapped `libphsh` fortran shared library and adds the ability to crudely compile
+on the fly (useful when installing this package from source distribution).
+"""
+import importlib
+import os
+import subprocess
+import sys
+from typing import Optional
+
+LIBPHSH_MODULE = "phaseshifts.lib.libphsh"
+
+FORTRAN_LIBS = {
+    LIBPHSH_MODULE: {"source": "libphsh.f", "module_name": LIBPHSH_MODULE},
+}
+
+
+def is_module_importable(module: str) -> bool:
+    """Determine whether `module` is importable."""
+    try:
+        is_importable = bool(importlib.import_module(module))
+    except ModuleNotFoundError:
+        is_importable = False
+    return is_importable
+
+
+def compile_f2py_shared_library(
+    source: str,
+    module_name: Optional[str] = None,
+    **f2py_kwargs,
+) -> int:
+    """Compile `source` into f2py wrapped shared library given by `module_name`.
+
+    Examples
+    --------
+    >>> compile_f2py_shared_library(**FORTRAN_LIBS[LIBPHSH_MODULE])
+
+    See Also
+    --------
+    numpy.f2py
+    """
+    return subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "numpy.f2py",
+            source,
+            "-m",
+            module_name or os.path.basename(source),
+            "-c",
+            *[f"--{key}={val!r}" for key, val in f2py_kwargs.items()],
+        ],
+        cwd=os.path.dirname(__file__),
+    )

--- a/phaseshifts/lib/libphsh.f
+++ b/phaseshifts/lib/libphsh.f
@@ -13,7 +13,7 @@
 !
 !  there are nr grid points, and distances are in bohr radii...
 !
-!  r(i)=rmin*(rmax/rmin)**(dfloat(i)/dfloat(nr)) , i=1,2,3,...nr-1,nr
+!  r(i)=rmin*(rmax/rmin)**(dble(i)/dble(nr)) , i=1,2,3,...nr-1,nr
 !
 !
 !
@@ -384,8 +384,8 @@
      +                 nr,r,r2,dl,q0,xm1,xm2,njrc,vi)
 
            xkappa=-1.d0
-           if (abs(xnj(i)) .gt. dfloat(nl(i))+0.25d0) xkappa=-nl(i)-1
-           if (abs(xnj(i)) .lt. dfloat(nl(i))-0.25d0) xkappa= nl(i)
+           if (abs(xnj(i)) .gt. dble(nl(i))+0.25d0) xkappa=-nl(i)-1
+           if (abs(xnj(i)) .lt. dble(nl(i))-0.25d0) xkappa= nl(i)
 
            call elsolve(i,occ(i),no(i),nl(i),xkappa,xnj(i),zorig,zeff,
      +                  evi,phe(1,i),v,q0,xm1,xm2,nr,r,dr,r2,dl,rel)
@@ -398,7 +398,7 @@
 
            do j=nr,1,-1
              dq=phe(j,i)*phe(j,i)
-             ekk=ekk+(evi-orb(j,i))*dr(j)*dq*dfloat(ll)/3.d0
+             ekk=ekk+(evi-orb(j,i))*dr(j)*dq*dble(ll)/3.d0
              ll=6-ll
            end do
 
@@ -479,7 +479,7 @@
 
            do la=lmx,0,-2
              lap=la+1
-             coeff=dfloat((li+li+1)*(lj+lj+1))/dfloat((la+la+1))**2.d0*
+             coeff=dble((li+li+1)*(lj+lj+1))/dble((la+la+1))**2.d0*
      +             cg(li,li,la,mi,-mi)*cg(lj,lj,la,mj,-mj)*
      +             cg(li,li,la,0 , 0 )*cg(lj,lj,la,0 , 0 )
              if (mi+mj .ne. 2*((mi+mj)/2)) coeff=-coeff
@@ -561,7 +561,7 @@
            do la=lmx,lmin,-2
              lap=la+1
 
-             coeff=dfloat((li+li+1)*(lj+lj+1))/dfloat((la+la+1))**2.d0*
+             coeff=dble((li+li+1)*(lj+lj+1))/dble((la+la+1))**2.d0*
      +             (cg(li,lj,la,-mi,mj)*cg(li,lj,la,0,0))**2.d0
              if ((occ(i) .gt. 1.d0) .or. (occ(j) .gt. 1.d0) .or.
      +           (xnj(i) .lt. 0.d0) .or. (xnj(j) .lt. 0.d0))
@@ -728,7 +728,7 @@
        dimension v(nrmax),q0(nrmax),xm1(nrmax),xm2(nrmax)
        dimension r(nrmax),dr(nrmax),r2(nrmax)
 
-       el=-zorig*zorig/dfloat(n*n)
+       el=-zorig*zorig/dble(n*n)
        eh=0.d0
        etol=0.0000000001d0
  155   e=(el+eh)/2.d0
@@ -749,7 +749,7 @@
 
        if (ief .ne. -1) eh=e
        if (eh-el .gt. etol) goto 155
-       if (abs(abs(xj)-abs(dfloat(l))) .gt. 0.25d0)
+       if (abs(abs(xj)-abs(dble(l))) .gt. 0.25d0)
      +    call augment(e,l,xj,phi,v,nr,r,dl)
        aa=0.d0
 
@@ -782,8 +782,8 @@
        c2=cc+cc
        xkappa=-1
 
-       if (abs(xj).gt.dfloat(l)+0.25d0) xkappa=-l-1
-       if (abs(xj).lt.dfloat(l)-0.25d0) xkappa= l
+       if (abs(xj).gt.dble(l)+0.25d0) xkappa=-l-1
+       if (abs(xj).lt.dble(l)-0.25d0) xkappa= l
 
        do j=4,nr-3
          if (phi(j).ne.0.d0) then
@@ -887,7 +887,7 @@
 
        ! figure the (Desclaux-Numerov) effective potential.
 
-       xlb=(dfloat(l)+0.5d0)**2.d0/2.d0
+       xlb=(dble(l)+0.5d0)**2.d0/2.d0
 
        do j=1,nr
          vj=v(j)
@@ -937,12 +937,12 @@
        dimension r(nrmax),dr(nrmax),r2(nrmax)
 
        ratio=rmax/rmin
-       dl=log(ratio)/dfloat(nr)
+       dl=log(ratio)/dble(nr)
        xratio=exp(dl)
        xr1=sqrt(xratio)-sqrt(1.d0/xratio)
 
        do i=1,nr
-         r(i)=rmin*xratio**dfloat(i)
+         r(i)=rmin*xratio**dble(i)
          dr(i)=r(i)*xr1
          r2(i)=r(i)*r(i)
        end do
@@ -1152,7 +1152,7 @@
 
        do i=1,32
          si(i)=-si(i-1)
-         fa(i)=dfloat(i)*fa(i-1)
+         fa(i)=dble(i)*fa(i-1)
        end do
 
        do l1=0,lmx
@@ -1167,7 +1167,7 @@
                if (lmin.lt.iabs(m3)) lmin=iabs(m3)
 
                do l3=lmin,l1+l2
-                 prefactor=dfloat(2*l3+1)
+                 prefactor=dble(2*l3+1)
                  prefactor=prefactor*fa(l3+l1-l2)/fa(l1+l2+l3+1)
                  prefactor=prefactor*fa(l3-l1+l2)/fa(l1-m1)
                  prefactor=prefactor*fa(l1+l2-l3)/fa(l1+m1)
@@ -1221,7 +1221,8 @@
        dimension njrc(4),njrcdummy(4),vi(nrmax,7),phe(nrmax,iorbs)
        dimension no(iorbs),nl(iorbs),nm(iorbs),xnj(iorbs)
        dimension ek(iorbs),ev(iorbs),occ(iorbs),is(iorbs)
-       dimension rpower(nrmax,0:7),orb(nrmax,iorbs)
+       ! FIXME: changed rpower dimension range from 0:7 -> 0:15 to be consistent and compile via meson
+       dimension rpower(nrmax,0:15),orb(nrmax,iorbs)
        dimension vctab(nrmax,0:3)
 
        do i=1,nel
@@ -1410,7 +1411,10 @@
        dimension njrc(4),orb(nrmax,iorbs)
        dimension q0(nrmax),xm1(nrmax),xm2(nrmax)
        dimension phi(nrmax),v(nrmax)
-       !dimension dummy(nrmax,7)
+       ! need this as an array not an implicit scalar
+       dimension dummy(nrmax,7)
+
+       dummy = 0.  ! explicitly initialise all values in the array to zero
 
        vl=-1000000.d0
        vh=+1000000.d0
@@ -1420,7 +1424,8 @@
          ns=1
          xkappa=-1.d0
 
-         call setqmm(i,orb,l,ns,idoflag,v,zeff,dummy,rel,
+        ! setqmm zorig needs array to be standards compliant fortran & compile
+         call setqmm(i,orb,l,ns,idoflag,v,zeff,dummy(1,7),rel,
      +               nr,r,r2,dl,q0,xm1,xm2,njrc,dummy)
 
          call integ(e,l,xkappa,n,nn,jrt,ief,xactual,phi,zeff,v,
@@ -1504,10 +1509,10 @@
          rcut=r(k)+xnodefrac*(r(j)-r(k))
        endif
 
-       jrc=1.d0+dfloat(nr-1)*log(rcut /rmin)/log(rmax/rmin)
+       jrc=1.d0+dble(nr-1)*log(rcut /rmin)/log(rmax/rmin)
        rcut=r(jrc)
        rtest=2.d0*rcut
-       jrt=1.d0+dfloat(nr-1)*log(rtest/rmin)/log(rmax/rmin)
+       jrt=1.d0+dble(nr-1)*log(rtest/rmin)/log(rmax/rmin)
        njrc(lp)=jrt
        rtest=r(jrt)
        switch=phi(jrt)/abs(phi(jrt))
@@ -1706,7 +1711,7 @@
          open (unit=20+l,status='unknown')
 
          do ii=1,200
-           q=dfloat(ii)/10.d0
+           q=dble(ii)/10.d0
            vq=0.d0
 
            do i=3,nr-2
@@ -1734,7 +1739,7 @@
        SI(0)=1.D0
 
        do I=1,32
-         FA(I)=Dfloat(I)*FA(I-1)
+         FA(I)=dble(I)*FA(I-1)
          SI(I)=-SI(I-1)
        end do
 
@@ -1744,7 +1749,7 @@
 
            do N=M+L,0,-2
              XI=0.D0
-             XF=2.D0/2.D0**Dfloat(N+L+M)
+             XF=2.D0/2.D0**dble(N+L+M)
              NN=(N+1)/2
              MM=(M+1)/2
              LL=(L+1)/2
@@ -1757,7 +1762,7 @@
 
                  do IC=MM,M
                    XCF=SI(IC)*FA(IC+IC)/FA(IC)/FA(M-IC)/FA(IC+IC-M)
-                   XI=XI+XF*AF*BF*XCF/Dfloat(IA*2+IB*2+IC*2-N-L-M+1)
+                   XI=XI+XF*AF*BF*XCF/dble(IA*2+IB*2+IC*2-N-L-M+1)
                  end do
 
                end do
@@ -1819,7 +1824,7 @@
 
        ! define the logarithmic grid
        do i=1,nr
-          r(i)=rmin*(rmax/rmin)**(dfloat(i)/dfloat(nr))
+          r(i)=rmin*(rmax/rmin)**(dble(i)/dble(nr))
        end do
 
        ! obtain the charge density on the logarithmic grid
@@ -3372,7 +3377,7 @@
 !    RMAX= maximum radial coordinate defining the logarithmic mesh used
 !          in relativistic calculation
 !    NR  = number of points in the mesh
-! the mesh is defined as r(i)=rmin*(rmax/rmin)**(dfloat(i)/dfloat(nr))
+! the mesh is defined as r(i)=rmin*(rmax/rmin)**(dble(i)/dble(nr))
 ! FOR EACH ATOMIC STATE I?
       subroutine RELA(RHO,RX,NX,NGRID)
 
@@ -3386,7 +3391,7 @@
 
        ! initialization of logarithmic grid
        do i=1,nr
-         rr(i)=rmin*(rmax/rmin)**(dfloat(i)/dfloat(nr))
+         rr(i)=rmin*(rmax/rmin)**(dble(i)/dble(nr))
        end do
 
        NS=nr
@@ -3607,7 +3612,7 @@
 !  SUBROUTINE TO CALCULATE NL PHASE SHIFTS (L=0,NL-1) FOR AN
 !  ATOMIC POTENTIAL TABULATED ON THE LOUCKS RADIAL GRID.
 !     V?  ATOMIC POTENTIAL (RYDBERGS)
-!     RX?  LOUCKS' EXPONENTIAL GRID  RX(I)=EXP(-8.8+0.05(I-1))
+!     RX?  LOUCKS` EXPONENTIAL GRID  RX(I)=EXP(-8.8+0.05(I-1))
 !     NGRID?  NUMBER OF TABULATED POINTS
 !     RAD?  LIMIT OF INTEGRATION OF SCHRODINGER EQUATION (A.U.)
 !     E?  ENERGY (RYDBERGS)
@@ -3963,7 +3968,8 @@
 
        return
 
-12     format(1P8E14.7, /, 14X, 1P7E14.7, /)
+       ! previous "format(1P8E14.7, /, 14X, 1P7E14.7, /)" does not compile
+12     format('( 1P8 E14.7 )', /, 14X, '( 1P7 E14.7 )', /)
 71     format(1F7.4)
 72     format(10F7.4)
 
@@ -4433,8 +4439,9 @@
        do I = 1, N
          J = T * (Y(I) - Y1) + 1.5
          P(J) = C
+         ! NOTE: format needed to be defined before use for some ansii compilers
+4        format(1X, '(1P2 E16.6)', 2X, 97A1)
          write(6, 4) X(I), Y(I), P
-4        format(1X, 1P2E16.6, 2X, 97A1)
          P(J) = B
          P(J0) = D
        end do

--- a/setup.py
+++ b/setup.py
@@ -1,61 +1,139 @@
 #!/usr/bin/env python
 import os
 import sys
+import sysconfig
 
 try:
-    from setuptools import find_packages
+    import phaseshifts
+except ModuleNotFoundError:
+    phaseshifts = None  # type: ignore [assignment]
+
+try:
+    from setuptools import find_packages, setup, Extension  # type: ignore [import-untyped]
 except ImportError:
-    from distutils.core import find_packages
+    from distutils.core import find_packages  # type: ignore [attr-defined]
+
+INCLUDE_DIRS = []
 
 # WARNING: numpy.distutils is completely removed in python 3.12 and deprecated for removal in python 3.11 by Oct 2025
 # The project will therefore need to be migrated to use a different build backend, see
 # https://numpy.org/doc/stable/reference/distutils_status_migration.html#distutils-status-migration
 try:
     from numpy.distutils.core import Extension, setup
-except ModuleNotFoundError:
-    if tuple(sys.version_info[:2]) >= (3, 11):
-        raise NotImplementedError(
-            "numpy.distutils has been removed for python {}".format(
-                ".".join(map(str, sys.version_info[:2]))
+
+    BUILD_BACKEND = "numpy.distutils"
+except ModuleNotFoundError as npy_err:
+    if tuple(sys.version_info[:2]) >= (3, 11) and "bdist_wheel" in sys.argv:
+        # TODO: Need to use migrate to a new f2py build backend, but have issues with pyproject.toml PEP-517 install
+        # FIXME: Currently skbuild with CMakeLists.txt does not work, check with `make libphsh.cmake`
+        try:
+            from skbuild import setup
+
+            BUILD_BACKEND = "skbuild"
+        except ImportError:
+            raise NotImplementedError(
+                "TODO: Generate binary wheels correctly using pyproject.toml, scikit-build and cmake"
+            ) 
+    elif tuple(sys.version_info[:2]) >= (3, 11):
+        # We can invoke f2py and compile manually
+        # HACK: Workaround missing distutils by invoking f2py directly
+        # FIXME: Generated wheels unaware of native extension & deemed universal; *.so must be included in MANIFEST.in
+        import subprocess
+
+        import numpy.f2py
+
+        BUILD_BACKEND = "numpy.f2py"
+        if not any(x in sys.argv for x in ("sdist", "wheel")):
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "numpy.f2py",
+                    "libphsh.f",
+                    "-m",
+                    "libphsh",
+                    "-c",
+                ],
+                cwd="./phaseshifts/lib",
             )
-        )
-    raise
+        INCLUDE_DIRS += [
+            f"-I{numpy.get_include()}",
+            f"-I{numpy.f2py.get_include()}",
+        ]
+    else:
+        raise npy_err from None
 
 try:
-    import py2exe
+    import py2exe  # noqa
 except ImportError:
     py2exe = None
 
 if len(sys.argv) == 1:
     sys.argv.append("install")
 
+CMAKE_ARGS = {}
+
+if BUILD_BACKEND == "skbuild":
+    CMAKE_ARGS = {
+        "cmake_args": [
+            f"-DPYTHON_INCLUDE_DIR=\"{sysconfig.get_path('include')}\""
+            f"-DPYTHON_LIBRARY=\"{sysconfig.get_config_var('LIBDIR')}\""
+        ]
+    }
+
+BUILD_EXT_INPLACE_ARGS = ["build_ext", "--inplace"]
+if len(sys.argv) < 2 and BUILD_BACKEND == "numpy.distutils":
+    # add build_ext and --inplace flags when performing: `python setup.py`
+    sys.argv.extend(BUILD_EXT_INPLACE_ARGS)
+elif BUILD_BACKEND == "numpy.f2py":
+    # FIXME: The following is a crude workaround to build_ext to avoid compiled libphsh*.so with undefined symbols
+    for arg in filter(lambda x: x in sys.argv, BUILD_EXT_INPLACE_ARGS):
+        sys.argv.remove(arg)
+    if "build" not in sys.argv:
+        sys.argv.append("build")
+
 # build f2py extensions
-f2py_exts = [
-    Extension(
-        name="phaseshifts.lib.libphsh",
-        extra_compile_args=["-fopenmp"],
-        extra_link_args=["-lgomp"],
-        sources=[os.path.join("phaseshifts", "lib", "libphsh.f")],
-    )
-]
+f2py_exts_sources = {
+    "libphsh": [
+        os.path.join(
+            "phaseshifts",
+            "lib",
+            "libphsh.f" + (".f" if BUILD_BACKEND == "numpy.distutils" else "module.c"),
+        )
+    ]
+}
+f2py_exts = (
+    []
+    if BUILD_BACKEND != "numpy.distutils"
+    else [
+        Extension(
+            name="phaseshifts.lib.libphsh",
+            extra_compile_args=["-fopenmp"],
+            extra_link_args=["-lgomp"],
+            sources=f2py_exts_sources["libphsh"],
+        )
+    ]
+)
 
 dist = setup(
     name="phaseshifts",
     packages=find_packages(),
-    version="0.1.6-dev",
+    version=getattr("phaseshifts", "__version__", None),
     author="Liam Deacon",
     author_email="liam.m.deacon@gmail.com",
     license="MIT License",
-    url="https://pypi.python.org/pypi/phaseshifts",
-    description="Python-based version of the Barbieri/Van Hove phase "
-    "shift calculation package for LEED/XPD modelling",
-    long_description=None
-    if not os.path.exists("README.rst")
-    else open("README.rst").read(),
+    url="https://github.com/Liam-Deacon/phaseshifts",
+    description=(
+        "Python-based version of the Barbieri/Van Hove phase "
+        "shift calculation package for LEED/XPD modelling"
+    ),
+    long_description=(
+        None if not os.path.exists("README.rst") else open("README.rst").read()
+    ),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",
-        "Environment :: X11 Applications :: Qt",  # The end goal is to have Qt or other GUI frontend
+        "Environment :: X11 Applications :: Qt",  # The end goal is lsto have Qt or other GUI frontend
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
@@ -64,14 +142,18 @@ dist = setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     keywords="phaseshifts atomic scattering muffin-tin diffraction",
-    include_package_data=True,
-    package_data={
-        # If any package contains *.txt or *.rst files, include them:
-        "": ["*.txt", "*.rst", "*.pyw", "ChangeLog"],
-        "lib": ["lib/*.f", "lib/*.c", "lib/*.h"],
-        "gui": ["gui/*.ui", "gui/*.bat"],
-        "gui/res": ["gui/res/*.*"],
-    },
+    # include_package_data=True,
+    package_data=(
+        {}
+        if BUILD_BACKEND == "skbuild"
+        else {
+            # If any package contains *.txt or *.rst files, include them:
+            ".": ["*.txt", "*.rst", "*.pyw", "ChangeLog"],
+            "lib": ["lib/*.f", "lib/*.c", "lib/*.h"] + ["*.so", "*.pyd"],
+            "gui": ["gui/*.ui", "gui/*.bat"],
+            "gui/res": ["gui/res/*.*"],
+        }
+    ),
     scripts=["phaseshifts/phsh.py"],
     install_requires=["scipy >= 0.7", "numpy >= 1.3", "periodictable"],
     ext_modules=f2py_exts,
@@ -93,8 +175,3 @@ dist = setup(
         else {}
     ),
 )
-
-if len(sys.argv) < 2:
-    # add build_ext and --inplace flags when performing: `python setup.py`
-    sys.argv.append("build_ext")
-    sys.argv.append("--inplace")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os.path
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_libphsh_fortran_wrapper.py
+++ b/tests/test_libphsh_fortran_wrapper.py
@@ -1,0 +1,18 @@
+import sys
+
+import pytest
+
+def test_import_libphsh():
+    """
+    GIVEN a compiled libphsh.f shared object
+    WHEN importing phaseshifts.lib.libphsh compiled wrapper extension
+    THEN import should be successful
+    """
+    ext = ".so" if sys.platform != "win32" else ".pyd"
+    try:
+        import phaseshifts.lib.libphsh  # noqa
+    except ModuleNotFoundError:
+        pytest.fail(f"libphsh*{ext} has not been compiled")
+    except ImportError as err:
+        err_message = f"{ext}: ".join(str(err).split(f"{ext}: ")[1:])
+        pytest.fail(f"Unable to import compiled libphsh due to: '{err_message}'")


### PR DESCRIPTION
Support python <3.12 `pip install` of package through `setup.py` modifications. 

To build a wheel do `make clean wheel`.

To install do `pip install dist/phaseshifts*.whl`

> **NOTE**: `pyproject.toml`  PEP-517 install is not yet implemented as there are issues with `skbuild` / `meson` build backends for `f2py`.