### PR TITLE
feat: Add `windows-latest` to build matrix

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -44,8 +44,12 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-cov
         pip install -r requirements.txt
-    - uses: ilammy/msvc-dev-cmd@v1
+    # NOTE: There are some limitations with Windows builds needing  
+    - name: Install Microsoft Visual C++ Redistributables
       if: matrix.os == 'windows-latest'
+      run: |
+        Install-Module -Name "VcRedist" -Force
+      shell: pwsh
     - name: Build binaries
       run: make
       shell: bash

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -17,18 +17,25 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          # - macos-latest
         python-version:
+          # NOTE: 2.7 through to 3.6 inclusive will be removed in a future release to remove development overhead 
+          - "2.7"
+          - "3.5"
+          - "3.6"
           - "3.7"
           # - "3.8"  # This version has issues with the build, but is not officially supported anyway
           - "3.9"
           - "3.10"
           - "3.11"
           # - "3.12"  # TODO: Support python 3.12, f2py backend broken and needs to be fixed, see issue #8
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -39,9 +46,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r requirements.txt
     - name: Build binaries
       run: make
+      shell: bash
     - name: Lint with flake8
       continue-on-error: true
       run: |
@@ -51,9 +59,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        if [ -d tests/ ]; then
-            pytest tests/  # test only when ready
-        fi
+        pytest tests/
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -25,10 +25,7 @@ jobs:
           - windows-latest
           # - macos-latest
         python-version:
-          # NOTE: 2.7 through to 3.6 inclusive will be removed in a future release to remove development overhead 
-          - "2.7"
-          - "3.5"
-          - "3.6"
+          # NOTE: 2.7 through to 3.6 inclusive are not provided in the ubuntu-latest runner
           - "3.7"
           # - "3.8"  # This version has issues with the build, but is not officially supported anyway
           - "3.9"

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          # - windows-latest  # TODO: Needs #32 to be resolved
           # - macos-latest
         python-version:
           # NOTE: 2.7 through to 3.6 inclusive are not provided in the ubuntu-latest runner
@@ -44,7 +44,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-cov
         pip install -r requirements.txt
-    # NOTE: There are some limitations with Windows builds needing  
+    # NOTE: There are some limitations with Windows builds needing to be visited in #32
     - name: Install Microsoft Visual C++ Redistributables
       if: matrix.os == 'windows-latest'
       run: |

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -44,6 +44,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-cov
         pip install -r requirements.txt
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: matrix.os == 'windows-latest'
     - name: Build binaries
       run: make
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ libphsh:
 
 #: Perform checks
 check: libphsh
-	$(PYTHON) -m pytest tests/
+	$(PYTHON) -m pytest tests/ --verbose
 
 test: check
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ModuleNotFoundError:
     phaseshifts = None  # type: ignore [assignment]
 
 try:
-    import setuptools
+    import setuptools  # type: ignore [import-untyped]
     from setuptools import find_packages, setup, Extension  # type: ignore [import-untyped]
 except ImportError:
     from distutils.core import find_packages  # type: ignore [attr-defined]
@@ -24,7 +24,7 @@ INCLUDE_DIRS = []
 try:
     import skbuild
 except ImportError:
-    skbuild = None
+    skbuild = None  # type: ignore [assignment]
 
 BUILD_BACKEND = None
 try:
@@ -69,14 +69,13 @@ except ModuleNotFoundError as npy_err:
                 cwd="./phaseshifts/lib",
             )
         INCLUDE_DIRS += [
-            f"-I{numpy.get_include()}",
-            f"-I{numpy.f2py.get_include()}",
+            "-I{}".format(x) for x in (numpy.get_include(), numpy.f2py.get_include())
         ]
     else:
         raise npy_err from None
 
 try:
-    import py2exe  # noqa
+    import py2exe  # type: ignore [import-not-found] # noqa
 except ImportError:
     py2exe = None
 
@@ -88,8 +87,8 @@ CMAKE_ARGS = {}
 if BUILD_BACKEND == "skbuild":
     CMAKE_ARGS = {
         "cmake_args": [
-            f"-DPYTHON_INCLUDE_DIR=\"{sysconfig.get_path('include')}\""
-            f"-DPYTHON_LIBRARY=\"{sysconfig.get_config_var('LIBDIR')}\""
+            '-DPYTHON_INCLUDE_DIR="{}"'.format(sysconfig.get_path("include")),
+            '-DPYTHON_LIBRARY="{}"'.format(sysconfig.get_config_var("LIBDIR")),
         ]
     }
 
@@ -127,7 +126,7 @@ f2py_exts = (
     ]
 )
 
-print(f"BUILD_BACKEND: {BUILD_BACKEND}")
+print("BUILD_BACKEND: {}".format(BUILD_BACKEND))
 
 dist = setup(
     name="phaseshifts",

--- a/tests/test_libphsh_fortran_wrapper.py
+++ b/tests/test_libphsh_fortran_wrapper.py
@@ -10,7 +10,6 @@ PHASESHIFTS_ROOT_DIR = os.path.dirname(phaseshifts.__file__)
 PHASESHIFTS_LIB_DIR = os.path.join(PHASESHIFTS_ROOT_DIR, "lib")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="TODO: Correctly locate libphsh shared object")
 def test_libphsh_exists():
     """
     GIVEN a package build including binaries of libphsh.f has been previously executed

--- a/tests/test_libphsh_fortran_wrapper.py
+++ b/tests/test_libphsh_fortran_wrapper.py
@@ -46,10 +46,11 @@ def test_import_libphsh():
         pytest.fail("libphsh*{} has not been compiled".format(ext))
     except ImportError as err:
         if sys.platform == "win32":
-            assert os.system("dumpbin /dependents {}{}libphsh.pyd".format(PHASESHIFTS_LIB_DIR, os.path.sep)) == 0
-        if sys.version[:2] >= (3, 8):
-            os.add_dll_directory(PHASESHIFTS_LIB_DIR)
-            import phaseshifts.lib.libphsh  # type: ignore [import-untyped] # noqa
+            os.system("dumpbin /dependents {}{}libphsh.pyd".format(PHASESHIFTS_LIB_DIR, os.path.sep)) == 0
+            if sys.version[:2] >= (3, 8):
+                os.add_dll_directory(PHASESHIFTS_LIB_DIR)
+                import phaseshifts.lib.libphsh  # type: ignore [import-untyped] # noqa
+                return  # success after adding DLL directory to path
         err_message = "{}: ".format(ext).join(str(err).split("{}: ".format(ext))[1:])
         pytest.fail(
             "Unable to import compiled libphsh due to: '{}'".format(err_message)

--- a/tests/test_libphsh_fortran_wrapper.py
+++ b/tests/test_libphsh_fortran_wrapper.py
@@ -47,7 +47,7 @@ def test_import_libphsh():
     except ImportError as err:
         if sys.platform == "win32":
             os.system("dumpbin /dependents {}{}libphsh.pyd".format(PHASESHIFTS_LIB_DIR, os.path.sep)) == 0
-            if tuple(map(int, sys.version[:2])) >= (3, 8):
+            if sys.version_info[:2] >= (3, 8):
                 os.add_dll_directory(PHASESHIFTS_LIB_DIR)
                 import phaseshifts.lib.libphsh  # type: ignore [import-untyped] # noqa
                 return  # success after adding DLL directory to path

--- a/tests/test_libphsh_fortran_wrapper.py
+++ b/tests/test_libphsh_fortran_wrapper.py
@@ -9,6 +9,8 @@ import phaseshifts
 PHASESHIFTS_ROOT_DIR = os.path.dirname(phaseshifts.__file__)
 PHASESHIFTS_LIB_DIR = os.path.join(PHASESHIFTS_ROOT_DIR, "lib")
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="TODO: Correctly locate libphsh shared object")
 def test_libphsh_exists():
     """
     GIVEN a package build including binaries of libphsh.f has been previously executed

--- a/tests/test_libphsh_fortran_wrapper.py
+++ b/tests/test_libphsh_fortran_wrapper.py
@@ -47,7 +47,7 @@ def test_import_libphsh():
     except ImportError as err:
         if sys.platform == "win32":
             os.system("dumpbin /dependents {}{}libphsh.pyd".format(PHASESHIFTS_LIB_DIR, os.path.sep)) == 0
-            if sys.version[:2] >= (3, 8):
+            if tuple(map(int, sys.version[:2])) >= (3, 8):
                 os.add_dll_directory(PHASESHIFTS_LIB_DIR)
                 import phaseshifts.lib.libphsh  # type: ignore [import-untyped] # noqa
                 return  # success after adding DLL directory to path


### PR DESCRIPTION
Add Windows build check to matrix

> NOTE: This is somewhat costly on available GitHub Action minutes under the free plan and therefore should perhaps be restricted somehow?