### PR TITLE
doc: Update alternatives link for AQuaLEED and mention possible docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,9 @@ A number of alternatives are available, notably the following:
       a useful [poster overview of phaseshifts
       calculations](https://physics.mff.cuni.cz/kfpp/povrchy/files/1179-Poster.pdf)).
       This is an officially mentioned piece of software on Michel Van
-      Hove's [LEEDPACK
-      webpage](https://www.icts.hkbu.edu.hk/VanHove_files/leed/leedpack.html). Although the
+      Hove's [LEED Calculation Homepage](https://www.icts.hkbu.edu.hk/VanHove_files/leed/leedpack.html). Although the
       poster mentions that the software is written in python, this
-      software is not (currently) distributed on <https://PyPI.org> and
+      software is not (currently) distributed on <https://PyPI.org> (or via alternative means such as a docker image on [DockerHub](https://www.docker.com/products/docker-hub/))  and
       therefore harder to integrate with other python LEED-related
       projects such as [CLEED](https://github.com/Liam-Deacon/CLEED) and
       [cleedpy](https://github.com/empa-scientific-it/cleedpy).

--- a/docs/included/alternatives.rst
+++ b/docs/included/alternatives.rst
@@ -3,13 +3,13 @@ Alternatives
 
 A number of alternatives are available, notably the following:
 
-1. `AQuaLEED <https://physics.mff.cuni.cz/kfpp/povrchy/software>`_ (with a useful
+1. `AQuaLEED <https://physics.mff.cuni.cz/kfpp/povrchy/files/>`_ (with a useful
    `poster overview of phaseshifts calculations <https://physics.mff.cuni.cz/kfpp/povrchy/files/1179-Poster.pdf>`_).
    This is an officially mentioned piece of software on Michel Van Hove's
-   `LEEDPACK webpage <https://www.icts.hkbu.edu.hk/VanHove_files/leed/leedpack.html>`_,
-   however when tested as of January 2024 the link appears to be dead (with a ``500 INTERNAL_SERVER_ERROR``).
+   `LEED Calculation Homepage <https://www.icts.hkbu.edu.hk/VanHove_files/leed/leedpack.html>`_.
    Furthermore, although the poster mentions that the software is written in python,
-   this software is not (currently) distributed on https://PyPI.org and therefore harder to
+   this software is not (currently) distributed on https://PyPI.org (or via alternative means such as a docker image
+   on `DockerHub <https://www.docker.com/products/docker-hub/>`_) and therefore harder to
    intergrate with other python LEED-related projects such as `CLEED <https://github.com/Liam-Deacon/CLEED>`_
    and `cleedpy <https://github.com/empa-scientific-it/cleedpy>`_.
 2. A fortran program is described in "`McGreevy, E., & Stewart, A.L. (- Apr 1978). <https://inis.iaea.org/search/search.aspx?orig_q=RN:9399501>`_


### PR DESCRIPTION
Fix broken AQuaLEED link (after searching online) for updating ReadTheDocs generated text

- Part of #78 