### PR TITLE
fix: Update Python version notes in test workflow

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -42,8 +42,7 @@ jobs:
           # - windows-latest  # TODO: Needs #32 to be resolved
           # - macos-latest
         python-version:
-          # NOTE: 2.7 through to 3.6 inclusive are not provided in the ubuntu-latest runner
-          - "3.7"
+          # NOTE: 2.7 through to 3.7 inclusive are not provided in the ubuntu-latest runner
           # - "3.8"  # This version has issues with the build, but is not officially supported anyway
           - "3.9"
           - "3.10"


### PR DESCRIPTION
## Affected Areas
- 🐍 Python Configuration

## Key Changes
- 🔧 Updated note on Python versions available
- 📉 Removed support for Python 2.7 to 3.6

## Summary by Sourcery

Update the GitHub Actions test workflow to drop unsupported Python versions and revise the availability note

Enhancements:
- Remove Python 3.7 from the test matrix
- Update the version note to indicate that Python 2.7 through 3.7 are not provided on ubuntu-latest